### PR TITLE
[#28] 질문 피드 페이지와 답변 페이지 공통 레이아웃 구현

### DIFF
--- a/openmind/src/Components/FeedCard.jsx
+++ b/openmind/src/Components/FeedCard.jsx
@@ -6,6 +6,8 @@ import EmptyAnswer from './EmptyAnswer';
 import FeedQuestion from './FeedQuestion';
 import RejectAnswer from './RejectAnswer';
 import SentAnswer from './SentAnswer';
+import Reaction from './Reaction';
+import BadgeBrown from './BadgeBrown';
 
 //api 연동 전 임시 데이터
 const demoData = {
@@ -16,7 +18,7 @@ const demoData = {
   username: '아초는고양이',
   answer:
     '그들을 불러 귀는 이상의 오직 피고, 가슴이 이상, 못할 봄바람이다. 찾아다녀도, 전인 방황하였으며, 대한 바이며, 이것이야말로 가치를 청춘의 따뜻한 그리하였는가? 몸이 열락의 청춘의 때문이다. 천고에 피어나는 간에 밝은 이상, 인생의 만물은 피다. 대중을 이성은 방황하여도, 그리하였는가? 크고 평화스러운 품에 방황하였으며, 말이다. 이상은 들어 예수는 크고 긴지라 역사를 피다. 얼음에 있음으로써 꽃 보배를 곧 가는 교향악이다. 우는 새 예가 우리의 것은 피다. 피가 그것을 어디 앞이 기쁘며, 이상의 열락의 위하여서 끝까지 것이다. 있는 봄바람을 방황하여도, 우리의 것은 작고 아니한 영원히 듣기만 운다.',
-  //answer: "",
+  //answer: '',
   isRejected: false,
 };
 
@@ -26,11 +28,9 @@ const FeedCard = () => {
   return (
     <div className={Styles.container}>
       <div className={Styles.nav}>
-        {/*여기 statusBadge는 태욱이가 만든 뱃지 컴포넌트로 변경 예정*/}
-        <div className={Styles.statusBadge}>답변 완료</div>
+        <BadgeBrown />
         <img className={Styles.kebab} src={KEBAB_SRC} />
       </div>
-
       <FeedQuestion type={demoData.type} createdAt={demoData.createdAt}>
         {demoData.question}
       </FeedQuestion>
@@ -45,7 +45,7 @@ const FeedCard = () => {
         <EmptyAnswer profileImg={demoData.profileImage} username={demoData.username} />
       )}
       <div className={Styles.line}></div>
-      {/* <Reaction /> 지인이가 리액션 컴포넌트 구현 완료하면 그 컴포넌트를 추가할 예정 */}
+      <Reaction />
     </div>
   );
 };

--- a/openmind/src/Components/QuestionReaction.jsx
+++ b/openmind/src/Components/QuestionReaction.jsx
@@ -4,7 +4,7 @@ import { ReactComponent as ThumbsDown } from '../Assets/Icon/iconThumbsDown.svg'
 import { ReactComponent as ThumbsUp } from '../Assets/Icon/iconThumbsUp.svg';
 import Styles from '../Styles/Reaction.module.css';
 
-import { ReactionAPI } from './ReactionAPI';
+import { ReactionAPI } from '../Utils/ReactionAPI';
 
 export function QuestionReaction({ type }) {
   const [like, setLike] = useState(null);
@@ -31,12 +31,12 @@ export function QuestionReaction({ type }) {
   const stop = () => {};
 
   return (
-    <div>
+    <div className={Styles.container}>
       {type === 'like' && (
         <div
           className={like ? Styles.clickLikeReaction : Styles.likeReaction}
           onClick={like ? stop : () => handleReaction()}>
-          <ThumbsUp fill={like ? `var(--blue50)` : `var(--gray40)`} />
+          <ThumbsUp fill={like ? 'var(--blue50)' : 'var(--gray40)'} />
           <p>좋아요</p>
           <p>{like}</p>
         </div>
@@ -45,7 +45,7 @@ export function QuestionReaction({ type }) {
         <div
           className={dislike ? Styles.clickDislikeReaction : Styles.likeReaction}
           onClick={dislike ? stop : () => handleReaction()}>
-          <ThumbsDown fill={dislike ? `var(--gray60)` : `var(--gray40)`} />
+          <ThumbsDown fill={dislike ? 'var(--gray60)' : 'var(--gray40)'} />
           <p>싫어요</p>
           <p>{dislike}</p>
         </div>

--- a/openmind/src/Layout/PostnAnswerLayout.jsx
+++ b/openmind/src/Layout/PostnAnswerLayout.jsx
@@ -1,0 +1,48 @@
+import Styles from '../Styles/PostnAnswerLayout.module.css';
+
+//import LOGO from '../Assets/Icon/logo.svg';
+import HEADER_IMG from '../Assets/Images/imageMainPage.svg';
+import PROFILE_IMG from '../Assets/Images/imageUserProfile.svg'; //추후 API 연동해서 받아오기
+import MESSAGE_ICON from '../Assets/Icon/iconMessages.svg';
+
+import ShareButton from '../Components/ShareButton';
+import FeedCard from '../Components/FeedCard';
+
+const PostnAnswerLayout = (/*{ children }*/) => {
+  return (
+    <>
+      <div className={Styles.header}>
+        {/*여기에 로고파일 추가해서 import하면 됩니당*/}
+        {/*<img src={LOGO} className={Styles.logo} />*/}
+        <img src={HEADER_IMG} className={Styles.headerImage} />
+      </div>
+      <div className={Styles.main}>
+        <div className={Styles.profileArea}>
+          <div className={Styles.profileGroup}>
+            {/*프로필 이미지와 유저 이름은 API로 받아올 예정*/}
+            <img src={PROFILE_IMG} className={Styles.profileImage} />
+            <div className={Styles.username}>아초는고양이</div>
+            <ShareButton />
+          </div>
+        </div>
+        <div className={Styles.feedContainer}>
+          <div className={Styles.questionInfo}>
+            <img src={MESSAGE_ICON} className={Styles.messageIcon} />
+            {/*질문 갯수도 API로 받아올 예정*/}
+            <div className={Styles.infoText}>3개의 질문이 있습니다.</div>
+          </div>
+          {/*피드 내용인 질문들과 답변들도 API로 받아올 예정
+          이후 질문 피드 페이지에서 레이아웃의 children props로 뿌릴 예정*/}
+          <div className={Styles.questionArea}>
+            {/* {children} */}
+            <FeedCard />
+            <FeedCard />
+            <FeedCard />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default PostnAnswerLayout;

--- a/openmind/src/Styles/Badge.module.css
+++ b/openmind/src/Styles/Badge.module.css
@@ -10,7 +10,6 @@
 
 .context {
   display: flex;
-  font-family: Pretendard;
   font-size: var(--caption);
   font-style: normal;
   font-weight: 500;

--- a/openmind/src/Styles/EmptyAnswer.module.css
+++ b/openmind/src/Styles/EmptyAnswer.module.css
@@ -50,6 +50,7 @@
   height: 18.6rem;
   background: var(--gray20);
   border-radius: 8px;
+  max-width: 20rem;
 }
 
 .answerInput::placeholder {
@@ -78,6 +79,7 @@
   line-height: 2.2rem;
   color: var(--gray10);
   border-radius: 8px;
+  max-width: 20rem;
 }
 
 .answerButton:hover {
@@ -95,5 +97,17 @@
   .profile {
     width: 4.8rem;
     height: 4.8rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .answerButton {
+    max-width: 54.8rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .answerInput {
+    max-width: 54.8rem;
   }
 }

--- a/openmind/src/Styles/EmptyAnswer.module.css
+++ b/openmind/src/Styles/EmptyAnswer.module.css
@@ -57,7 +57,6 @@
   align-self: stretch;
   position: absolute;
   top: 16px;
-  font-family: Pretendard;
   font-size: 1.6rem;
   font-weight: 400;
   line-height: 2.2rem;
@@ -73,7 +72,6 @@
   padding: 1.2rem 2.4rem;
   height: 4.6rem;
   background: var(--brown30);
-  font-family: Pretendard;
   font-size: 1.6rem;
   font-weight: 400;
   line-height: 2.2rem;
@@ -91,22 +89,13 @@
     font-size: 1.8rem;
     line-height: 2.4rem;
   }
-}
-
-@media (min-width: 768px) {
   .profile {
     width: 4.8rem;
     height: 4.8rem;
   }
-}
-
-@media (min-width: 768px) {
   .answerButton {
     max-width: 54.8rem;
   }
-}
-
-@media (min-width: 768px) {
   .answerInput {
     max-width: 54.8rem;
   }

--- a/openmind/src/Styles/FeedCard.module.css
+++ b/openmind/src/Styles/FeedCard.module.css
@@ -4,17 +4,11 @@
   align-items: flex-start;
   flex-direction: column;
   padding: 2.4rem;
-  box-shadow: 0rem 0.4rem 0.4rem 0rem rgba(140, 140, 140, 0.25);
+  box-shadow: var(--shadow1pt);
   width: 29.5rem;
-  height: auto;
+  height: 100%;
   background: var(--gray10);
   border-radius: 16px;
-
-  @media (min-width: 768px) {
-    width: 68.4rem;
-    gap: 3.2rem;
-    padding: 3.2rem;
-  }
 }
 
 .nav {
@@ -22,10 +16,6 @@
   justify-content: space-between;
   width: 24.7rem;
   height: 2.6rem;
-
-  @media (min-width: 768px) {
-    width: 63.6rem;
-  }
 }
 
 .kebab {
@@ -37,4 +27,17 @@
   align-self: stretch;
   height: 0.1rem;
   background: var(--gray30);
+}
+
+
+@media (min-width: 768px) {
+  .container {
+    width: 68.4rem;
+    gap: 3.2rem;
+    padding: 3.2rem;
+  }
+
+  .nav {
+    width: 63.6rem;
+  }
 }

--- a/openmind/src/Styles/FeedCard.module.css
+++ b/openmind/src/Styles/FeedCard.module.css
@@ -5,11 +5,13 @@
   flex-direction: column;
   padding: 2.4rem;
   box-shadow: 0rem 0.4rem 0.4rem 0rem rgba(140, 140, 140, 0.25);
-  width: 68.4rem;
+  width: 29.5rem;
+  height: auto;
   background: var(--gray10);
   border-radius: 16px;
 
   @media (min-width: 768px) {
+    width: 68.4rem;
     gap: 3.2rem;
     padding: 3.2rem;
   }
@@ -18,26 +20,12 @@
 .nav {
   display: flex;
   justify-content: space-between;
-  width: 63.6rem;
+  width: 24.7rem;
   height: 2.6rem;
 
   @media (min-width: 768px) {
-    width: 62rem;
+    width: 63.6rem;
   }
-}
-
-.statusBadge {
-  display: flex;
-  gap: 1rem;
-  align-items: center;
-  justify-content: center;
-  padding: 0.4rem 1.2rem;
-  border: 1px solid #542f1a;
-  width: 7.6rem;
-  height: 2.6rem;
-  background: #fff;
-  color: #542f1a;
-  border-radius: 8px;
 }
 
 .kebab {

--- a/openmind/src/Styles/FeedQuestion.module.css
+++ b/openmind/src/Styles/FeedQuestion.module.css
@@ -20,6 +20,7 @@
   font-weight: 400;
   line-height: 2.2rem;
   color: var(--gray60);
+  word-break: break-all;
 }
 
 @media (min-width: 768px) {

--- a/openmind/src/Styles/FeedQuestion.module.css
+++ b/openmind/src/Styles/FeedQuestion.module.css
@@ -7,7 +7,6 @@
 }
 
 .infoGroup {
-  font-family: Pretendard;
   font-size: 1.4rem;
   font-weight: 500;
   line-height: 1.8rem;

--- a/openmind/src/Styles/InputField.module.css
+++ b/openmind/src/Styles/InputField.module.css
@@ -18,7 +18,6 @@
 
 .input {
   flex: 1 0 0;
-  font-family: Pretendard;
   font-size: var(--body3);
   font-weight: 400;
   line-height: 2.2rem;

--- a/openmind/src/Styles/InputTextArea.module.css
+++ b/openmind/src/Styles/InputTextArea.module.css
@@ -5,7 +5,6 @@
   width: 33.6rem;
   height: 14rem;
   background: var(--gray20);
-  font-family: Pretendard;
   font-size: var(--body3);
   font-weight: 400;
   line-height: 2.2rem;

--- a/openmind/src/Styles/PostnAnswerLayout.module.css
+++ b/openmind/src/Styles/PostnAnswerLayout.module.css
@@ -1,0 +1,171 @@
+.header {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.headerImage {
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 90.6rem;
+  height: 17.7rem;
+  flex-shrink: 0;
+}
+
+.logo {
+  position: absolute;
+  bottom: 10rem;
+  display: flex;
+  width: 12.4rem;
+  height: 4.9rem;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.main {
+  background: var(--gray20);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4rem;
+}
+
+.profileArea {
+  position: relative;
+}
+
+.profileGroup {
+  position: absolute;
+  bottom: -12rem;
+  right: -7.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.2rem;
+  z-index: 10;
+}
+
+.profileImage {
+  display: flex;
+  width: 10.4rem;
+  height: 10.4rem;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.username {
+  color: var(--gray60);
+  font-family: Pretendard;
+  font-size: 2.4rem;
+  font-weight: 400;
+  line-height: 3rem;
+}
+
+.feedContainer {
+  display: flex;
+  width: 32.7rem;
+  padding: 1.6rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.6rem;
+  border-radius: 16px;
+  border: 1px solid var(--brown20);
+  background: var(--brown10);
+  margin-top: 16rem;
+}
+
+.questionInfo {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.messageIcon {
+  width: 2.2rem;
+  height: 2.2rem;
+}
+
+.infoText {
+  color: var(--brown40);
+  font-family: Actor;
+  font-size: 1.8rem;
+  font-weight: 400;
+  line-height: 2.4rem;
+}
+
+.questionArea {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+}
+
+@media (min-width: 768px) {
+  .questionArea {
+    gap: 2rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .headerImage {
+    width: 120rem;
+    height: 23.4rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .logo {
+    bottom: 13rem;
+    width: 17rem;
+    height: 6.7rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .profileGroup {
+    bottom: -13rem;
+    right: -9.5rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .profileImage {
+    width: 13.6rem;
+    height: 13.6rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .username {
+    font-size: 3.2rem;
+    line-height: 4rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .feedContainer {
+    width: 70.4rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .messageIcon {
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .infoText {
+    font-size: 2rem;
+    line-height: 2.5rem;
+  }
+}

--- a/openmind/src/Styles/PostnAnswerLayout.module.css
+++ b/openmind/src/Styles/PostnAnswerLayout.module.css
@@ -11,7 +11,6 @@
   align-items: center;
   width: 90.6rem;
   height: 17.7rem;
-  flex-shrink: 0;
 }
 
 .logo {
@@ -22,7 +21,6 @@
   height: 4.9rem;
   justify-content: center;
   align-items: center;
-  flex-shrink: 0;
 }
 
 .main {
@@ -61,7 +59,6 @@
 
 .username {
   color: var(--gray60);
-  font-family: Pretendard;
   font-size: 2.4rem;
   font-weight: 400;
   line-height: 3rem;
@@ -97,7 +94,7 @@
 .infoText {
   color: var(--brown40);
   font-family: Actor;
-  font-size: 1.8rem;
+  font-size: var(--body2);
   font-weight: 400;
   line-height: 2.4rem;
 }
@@ -112,58 +109,34 @@
   .questionArea {
     gap: 2rem;
   }
-}
-
-@media (min-width: 768px) {
   .headerImage {
     width: 120rem;
     height: 23.4rem;
   }
-}
-
-@media (min-width: 768px) {
   .logo {
     bottom: 13rem;
     width: 17rem;
     height: 6.7rem;
   }
-}
-
-@media (min-width: 768px) {
   .profileGroup {
     bottom: -13rem;
     right: -9.5rem;
   }
-}
-
-@media (min-width: 768px) {
   .profileImage {
     width: 13.6rem;
     height: 13.6rem;
   }
-}
-
-@media (min-width: 768px) {
   .username {
     font-size: 3.2rem;
     line-height: 4rem;
   }
-}
-
-@media (min-width: 768px) {
   .feedContainer {
     width: 70.4rem;
   }
-}
-
-@media (min-width: 768px) {
   .messageIcon {
     width: 2.4rem;
     height: 2.4rem;
   }
-}
-
-@media (min-width: 768px) {
   .infoText {
     font-size: 2rem;
     line-height: 2.5rem;

--- a/openmind/src/Styles/Reaction.module.css
+++ b/openmind/src/Styles/Reaction.module.css
@@ -1,21 +1,26 @@
+.container {
+  display: inline-flex;
+  flex-direction: row;
+}
+
 .likeReaction,
 .dislikeReaction {
   display: inline-flex;
-  gap: 6px;
+  gap: 0.6rem;
   align-items: center;
   color: var(--gray40);
 }
 
 .clickLikeReaction {
   display: inline-flex;
-  gap: 6px;
+  gap: 0.6rem;
   align-items: center;
   color: var(--blue50);
 }
 
 .clickDislikeReaction {
   display: inline-flex;
-  gap: 6px;
+  gap: 0.6rem;
   align-items: center;
   color: var(--gray60);
 }

--- a/openmind/src/Styles/RejectAnswer.module.css
+++ b/openmind/src/Styles/RejectAnswer.module.css
@@ -39,7 +39,6 @@
 }
 
 .createdAt {
-  font-family: Pretendard;
   font-size: 1.4rem;
   font-weight: 500;
   line-height: 1.8rem;
@@ -47,7 +46,6 @@
 }
 
 .answer {
-  font-family: Pretendard;
   font-size: 1.6rem;
   font-weight: 400;
   line-height: 2.2rem;
@@ -60,9 +58,6 @@
     width: 4.8rem;
     height: 4.8rem;
   }
-}
-
-@media (min-width: 768px) {
   .username {
     font-size: 1.8rem;
     line-height: 2.4rem;

--- a/openmind/src/Styles/SentAnswer.module.css
+++ b/openmind/src/Styles/SentAnswer.module.css
@@ -40,7 +40,6 @@
 }
 
 .createdAt {
-  font-family: Pretendard;
   font-size: 1.4rem;
   font-weight: 500;
   line-height: 1.8rem;
@@ -48,7 +47,6 @@
 }
 
 .answer {
-  font-family: Pretendard;
   font-size: 1.6rem;
   font-weight: 400;
   line-height: 2.2rem;
@@ -62,29 +60,17 @@
   .container {
     max-width: 59.2rem;
   }
-}
-
-@media (min-width: 768px) {
   .profile {
     width: 4.8rem;
     height: 4.8rem;
   }
-}
-
-@media (min-width: 768px) {
   .username {
     font-size: 1.8rem;
     line-height: 2.4rem;
   }
-}
-
-@media (min-width: 768px) {
   .answerArea {
     max-width: 54.8rem;
   }
-}
-
-@media (min-width: 768px) {
   .answer {
     max-width: 54.8rem;
   }

--- a/openmind/src/Styles/SentAnswer.module.css
+++ b/openmind/src/Styles/SentAnswer.module.css
@@ -3,7 +3,7 @@
   gap: 1.2rem;
   align-items: flex-start;
   flex-direction: row;
-  width: 59.2rem;
+  max-width: 24.4rem;
 }
 
 .profile {
@@ -21,6 +21,7 @@
   align-items: flex-start;
   flex: 1 0 0;
   flex-direction: column;
+  max-width: 20rem;
 }
 
 .infoGroup {
@@ -53,6 +54,14 @@
   line-height: 2.2rem;
   color: var(--gray60);
   word-break: break-all;
+  align-self: stretch;
+  max-width: 20rem;
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 59.2rem;
+  }
 }
 
 @media (min-width: 768px) {
@@ -66,5 +75,17 @@
   .username {
     font-size: 1.8rem;
     line-height: 2.4rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .answerArea {
+    max-width: 54.8rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .answer {
+    max-width: 54.8rem;
   }
 }

--- a/openmind/src/Styles/Toast.module.css
+++ b/openmind/src/Styles/Toast.module.css
@@ -5,7 +5,6 @@
   padding: 1.2rem 2rem;
   box-shadow: var(--shadow2pt);
   background: var(--gray60);
-  font-family: Pretendard;
   font-size: var(--caption);
   font-style: normal;
   font-weight: 500;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#28_PostnAnswerLayout -> dev

### 이슈 링크
[#28]

### 변경 사항
질문 피드 페이지와 답변 페이지의 공통 레이아웃 컴포넌트를 반응형도 고려하며 구현했습니다.
또한, FeedCard 컴포넌트 내부도 반응형을 고려하여 구현하였고, (max-width로 너비를 조정함으로써!)
Reaction 컴포넌트와 Badge 컴포넌트도 FeedCard 컴포넌트 내부에 포함하였습니다. 
(지수언니가 만든 button 컴포넌트와 태욱이가 만든 input 컴포넌트는 현재 페이지에 도입시키려면 너무 많은 부분을 수정해야해서ㅠㅠ 추후 리팩토링 작업에서 포함시키겠습니다.)

레이아웃 컴포넌트에서 따로 API로 불러와서 도입시킬 예정인 부분은 주석으로 작성하였습니다.


### 테스트 결과
<img width="236" alt="모바일_있음_반응형" src="https://github.com/sprint-part2-team14/OpenMind/assets/67824465/9387e745-f2b6-41cf-b69b-179e2c2b61db">
<img width="932" alt="태블릿피씨_있음_반응형" src="https://github.com/sprint-part2-team14/OpenMind/assets/67824465/8abac411-236b-4a94-8c8e-c807f107bb7a">

<img width="254" alt="모바일_비었음_반응형" src="https://github.com/sprint-part2-team14/OpenMind/assets/67824465/738a371a-aaf4-4252-9dc3-d7399bf25e95">
<img width="950" alt="태블릿피씨_비었음_반응형" src="https://github.com/sprint-part2-team14/OpenMind/assets/67824465/1317c42d-7a31-4108-a6e8-fcf622496017">

<img width="265" alt="모바일_거절_반응형" src="https://github.com/sprint-part2-team14/OpenMind/assets/67824465/a3ca3f32-a420-4b9d-9cfe-245e4dab46aa">
<img width="938" alt="태블릿피씨_거절_반응형" src="https://github.com/sprint-part2-team14/OpenMind/assets/67824465/671f06d2-5ec5-4b16-9904-f10c9b6d01aa">

